### PR TITLE
Fixing typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ The integration can be implemented without any special work using Djax:
 		  class ACE:
 		     content_type = 'Article'
 		     field_map = {
-		         'author','author',
+		         'author':'author',
 		         'title':'title',
 		         'body':'body',
 		     }
@@ -92,7 +92,7 @@ What if a foreign key relationship is nullable?  In the example given above, wha
 		  class ACE:
 		     content_type = 'Article'
 		     field_map = {
-		         'author',NullableForeignKeyConverter('author'),
+		         'author':NullableForeignKeyConverter('author'),
 		         'title':'title',
 		         'body':'body',
 		     }


### PR DESCRIPTION
At some place the `field_map` uses comma instead of colon.
